### PR TITLE
Update bazel dependencies and readme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
+      // Save after you stop typing for 500ms
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 500,
+
+    // Restore dirty files after restarts (prevents loss)
+    "files.hotExit": "onExitAndWindowClose",
     // A language server that uses c++ bazel external repositories
     // to enable c++ files navigation support and autocompletion
     "bazel.lsp.command": "starpls",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,16 +1,21 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-load("@poetry_deps//:requirements.bzl", "all_whl_requirements")
 load("@poetry_lock_file//:requirements.bzl", "all_requirements")
 load("@rules_pycross//pycross:defs.bzl", "pycross_lock_file", "pycross_poetry_lock_model")
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
+
+package(default_visibility = ["//visibility:public"])
 
 # gazelle:python_root
 # gazelle:python_label_convention deps:$distribution_name$
 # gazelle:python_label_normalization pep503
+
+# gazelle:cc_group unit
+# gazelle:resolve cc gtest/gtest.h @googletest//:gtest_main
+
+# --- Gazelle -----------------------------------------------------------------
 gazelle_binary(
     name = "gazelle_multilang",
     languages = DEFAULT_LANGUAGES + [
@@ -19,9 +24,6 @@ gazelle_binary(
     ],
     tags = ["manual"],
 )
-
-# gazelle:cc_group unit
-# gazelle:resolve cc gtest/gtest.h @googletest//:gtest_main
 
 gazelle(
     name = "gazelle",
@@ -36,12 +38,14 @@ gazelle(
     tags = ["manual"],
 )
 
-modules_mapping(
-    name = "gazelle.metadata",
-    tags = ["manual"],
-    wheels = all_requirements,
-)
+# Generate Python modules mapping for Gazelle from the vendored Poetry lock repo.
+# modules_mapping(
+#     name = "gazelle.metadata",
+#     tags = ["manual"],
+#     wheels = all_requirements,
+# )
 
+# If you want a manifest file for debugging, uncomment the target below.
 # gazelle_python_manifest(
 #     name = "gazelle.mapping",
 #     modules_mapping = ":gazelle.metadata",
@@ -49,25 +53,21 @@ modules_mapping(
 #     tags = ["manual"],
 # )
 
+# --- Buildifier --------------------------------------------------------------
 buildifier(
     name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     lint_mode = "warn",
     mode = "diff",
 )
 
 buildifier(
     name = "buildifier.fix",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     mode = "fix",
 )
 
-package(default_visibility = ["//visibility:public"])
-
+# --- rules_pycross: Poetry lock -> vendored lock file ------------------------
 pycross_poetry_lock_model(
     name = "poetry_lock_model",
     lock_file = "//:poetry.lock",
@@ -86,8 +86,6 @@ pycross_lock_file(
 
 write_source_files(
     name = "update_poetry_lock_file",
-    files = {
-        "poetry_lock_file.bzl": ":updated_poetry_lock_file.bzl",
-    },
+    files = {"poetry_lock_file.bzl": ":updated_poetry_lock_file.bzl"},
     tags = ["manual"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,94 +3,47 @@ module(
     version = "0.0.1",
 )
 
-# Only direct dependencies need to be listed below.
-# Please keep the versions in sync with the versions in the WORKSPACE file.
-# see https://registry.bazel.build/
+# --- Core deps ---------------------------------------------------------------
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.8")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.6.3")
+bazel_dep(name = "rules_pycross", version = "0.8.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
-#bazel_dep(name = "com_github_bazelbuild_buildtools", version = "2.13.6")
+bazel_dep(name = "fmt", version = "12.0.0")
+bazel_dep(name = "freertos", version = "11.1.0.bcr.2")
 
-# gazelle
+# --- Gazelle (Go-based dependency generator) --------------------------------
 bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
-bazel_dep(name = "rules_python_gazelle_plugin", version = "1.6.1")  # same version as rules_python
+bazel_dep(name = "rules_python_gazelle_plugin", version = "1.6.3")
 bazel_dep(name = "gazelle_cc", version = "0.1.0")
 
-#### DEV ONLY DEPENDENCIES BELOW HERE ####
-bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
-
-# Hedron's Compile Commands Extractor for Bazel
-# https://github.com/hedronvision/bazel-compile-commands-extractor
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
-    module_name = "hedron_compile_commands",
-    commit = "0e990032f3c5a866e72615cf67e5ce22186dcb97",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-    # Replace the commit hash (above) with the latest (https://github.com/hedronvision/bazel-compile-commands-extractor/commits/main).
-    # Even better, set up Renovate and let it do the work for you (see "Suggestion: Updates" in the README).
-)
-
-bazel_dep(
-    name = "buildifier_prebuilt",
-    version = "8.2.0.2",
-    dev_dependency = True,
-)
-
-# Bzlmod
-# buildifier_prebuilt = use_extension("//:defs.bzl", "buildifier_prebuilt_deps_extension")
-# buildifier_prebuilt.toolchains(version = "4.2.5")
-# use_repo(
-#     buildifier_prebuilt,
-#     "buildifier_prebuilt_toolchains",
-# )
-
-# remote execution
+# --- Remote execution / toolchains ------------------------------------------
 bazel_dep(name = "toolchains_buildbuddy")
-
 git_override(
     module_name = "toolchains_buildbuddy",
     commit = "66146a3015faa348391fcceea2120caa390abe03",
     remote = "https://github.com/buildbuddy-io/buildbuddy-toolchain.git",
 )
 
-# Use the extension to create toolchain and platform targets
+# Create BuildBuddy toolchain repo
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
-
-# buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
-
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
-# bazel_dep(name = "hermetic_cc_toolchain", version = "4.0.1")
-
-# toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
-# use_repo(toolchains, "zig_sdk")
-
-# register_toolchains(
-#     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31",
-#     "@zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.31",
-#     # "@zig_sdk//toolchain:windows_amd64",
-#     # "@zig_sdk//toolchain:windows_arm64",
-#     "@zig_sdk//toolchain:darwin_amd64",
-#     "@zig_sdk//toolchain:darwin_arm64",
-# )
-
-bazel_dep(name = "rules_pycross", version = "0.8.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
-
-# rules_python
+# --- Python toolchains (rules_python) ----------------------------------------
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-
-# The default is latest - 1 to make sure nothing assumes latest == default
 python.toolchain(
     is_default = True,
     python_version = "3.10.11",
 )
-# python.toolchain(python_version = "3.10.11")
 
-# rules_pycross
-environments = use_extension("@rules_pycross//pycross/extensions:environments.bzl", "environments")
+# --- rules_pycross: environments & locks ------------------------------------
+# Define target environments for cross-compiled wheels
+environments = use_extension(
+    "@rules_pycross//pycross/extensions:environments.bzl",
+    "environments",
+)
 environments.create_for_python_toolchains(
     name = "rules_pycross_e2e_environments",
     platforms = [
@@ -98,34 +51,52 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        # "3.10.11",
-        "3.10.11",
-    ],
+    python_versions = ["3.10.11"],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock_import = use_extension("@rules_pycross//pycross/extensions:lock_import.bzl", "lock_import")
+# Import Poetry lock into external repos
+lock_import = use_extension(
+    "@rules_pycross//pycross/extensions:lock_import.bzl",
+    "lock_import",
+)
 lock_import.import_poetry(
     lock_file = "//:poetry.lock",
     project_file = "//:pyproject.toml",
     repo = "poetry_deps",
-    # target_environments = ["@rules_pycross_e2e_environments//:environments"],
 )
 
-lock_repos = use_extension("@rules_pycross//pycross/extensions:lock_repos.bzl", "lock_repos")
+lock_repos = use_extension(
+    "@rules_pycross//pycross/extensions:lock_repos.bzl",
+    "lock_repos",
+)
 use_repo(lock_repos, "poetry_deps")
 
-# Lock repo for vended lock file
-lock_file = use_extension("@rules_pycross//pycross/extensions:lock_file.bzl", "lock_file")
+# Vendored lock file repo
+lock_file = use_extension(
+    "@rules_pycross//pycross/extensions:lock_file.bzl",
+    "lock_file",
+)
 lock_file.instantiate(
     name = "poetry_lock_file",
     lock_file = "//:poetry_lock_file.bzl",
 )
-use_repo(
-    lock_file,
-    "poetry_lock_file",
+use_repo(lock_file, "poetry_lock_file")
+
+# --- Dev-only deps -----------------------------------------------------------
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
+
+# Buildifier (prebuilt)
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.0.2",
+    dev_dependency = True,
 )
 
-bazel_dep(name = "fmt", version = "12.0.0")
-bazel_dep(name = "freertos", version = "11.1.0.bcr.2")
+# Hedron compile_commands extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "0e990032f3c5a866e72615cf67e5ce22186dcb97",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Inspired by [Mizux/bazel-pybind11](https://github.com/Mizux/bazel-pybind11)
 
 - bazel modules
 - bazelisk
-- gazelle with python plugin
+- gazelle with python and cpp plugin
+- pyproject + poetry + rules_python + rules_pycross
 - buildifier
 - usage of numpy dependancy
+- supports remote build/execution
 
 ## IDE
 
@@ -70,20 +72,120 @@ sort_array([9, 5, 3])
 sort_array([9, -1, 10, 0, 3])
 ```
 
-### Build in docker
+## Gazelle - Automated BUILD file generation
 
+Gazelle automatically generates and updates BUILD.bazel files for your project. This workspace is configured with multi-language Gazelle support.
+
+### Using Gazelle
+
+Gazelle is configured to support Python and C++ (other languages can also be configured).
+
+```bash
+# Generate/update BUILD files for all languages (C++, Python, Go)
+bazel run //:gazelle
+
+# Check what Gazelle would change without applying (dry-run)
+bazel run //:gazelle.check
 ```
-docker run \
+
+**For C++ projects**, Gazelle will:
+- Detect header and source files
+- Generate appropriate `cc_library`, `cc_binary`, and `cc_test` targets
+- Resolve dependencies between targets
+- Support Conan dependencies when configured (TODO)
+
+**For Python projects**, Gazelle will:
+- Generate `py_library`, `py_binary`, and `py_test` targets
+- Detect imports and create appropriate dependencies
+- Handle package structure and module dependencies
+- Integrate with Poetry/pip dependencies
+
+The configuration is defined in [BUILD.bazel:11-16](BUILD.bazel#L11-L16).
+
+### Adding new external Python dependencies
+
+When adding new external Python dependencies, follow these steps:
+
+1. **Add dependency to pyproject.toml**:
+   ```toml
+   [tool.poetry.dependencies]
+   new-package = "^1.0.0"
+   ```
+
+2. **Update Poetry lock file**:
+   ```bash
+   poetry lock
+   ```
+
+3. **Generate new Bazel lock file**:
+   ```bash
+   bazel run //:update_poetry_lock_file
+   ```
+
+4. **Update Gazelle mappings and BUILD files**:
+   ```bash
+   bazel run //:gazelle
+   ```
+
+This workflow uses `rules_pycross` for cross-platform Python dependency management and Poetry for dependency resolution.
+
+
+### Build in Docker
+
+```bash
+# Start interactive Docker container with Bazel
+docker run --rm -it \
   --platform linux/amd64 \
   --entrypoint /bin/bash \
   -v "$(pwd)":/src/workspace \
   -v /tmp/build_output:/tmp/build_output \
   -w /src/workspace \
-  gcr.io/bazel-public/bazel:8.0.1 \
-  -c "bazel build //... && bazel test //... && bazel build //sortcpp:wheel"
+  gcr.io/bazel-public/bazel:8.4.1
 ```
 
+Inside the container, you can use regular Bazel commands:
 
+```bash
+# Build all targets
+bazel build //...
+
+# Run tests
+bazel test //...
+
+# Build Python wheel
+bazel build //sortcpp:wheel
+
+# Use remote execution (if configured)
+bazel build //... --config=cache --config=remote_amd
+```
+
+This provides a consistent Linux AMD64 environment for builds and testing.
+
+## Remote Build and Execution
+
+This project supports remote build and execution for faster builds through caching and distributed execution.
+
+### Setup
+
+Remote execution can be configured with services like [BuildBuddy](https://www.buildbuddy.io/docs/quickstart/). Setup typically takes about 10 minutes to configure.
+
+Once configured, you can use flags like:
+```bash
+# Build with remote cache and execution
+bazel build //... --config=cache --config=remote
+
+# Test with remote execution
+bazel test //... --config=cache --config=remote
+```
+
+### Benefits
+
+- **Faster builds**: Distributed execution across multiple machines
+- **Build caching**: Shared cache across team and CI/CD
+- **Cross-platform builds**: Build for different architectures without local toolchains
+- **Build insights**: Web UI for build analysis and debugging
+
+For setup instructions, see the [BuildBuddy Quickstart Guide](https://www.buildbuddy.io/docs/quickstart/).
 
 ## Other examples on how to build python wheels
 
@@ -104,47 +206,3 @@ https://www.youtube.com/watch?v=rB7c69Z5Kus
 
 - nanobind
 https://nanobind.readthedocs.io/en/latest/
-
-# TODO
-
-- Configure [Renovate](https://github.com/renovatebot/renovate) to keep the dependencies up-to-date
-
-
-
-
-# remote build and remote execution status:
-
-## python
-
-### pure rules_python
-
-Very problematic because of requirements and pip. They are platform specific.
-
-### rules_pycross
-
-Better. Tested in combination with poetry and it works. Remote build, remote test works good. gazelle is problematic, will require some change. 
-
-
-# running in docker
-
-```
-docker run --rm -it --platform=linux/arm64 \
-  -v "$(pwd):/app" \
-  -w /app \
-  ubuntu:24.04 \
-  /bin/bash
-```
-
-require:
-```
-apt-get update
-
-apt-get install -y curl ca-certificates git python3 g++ 
-
-curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-arm64 -o /usr/local/bin/bazel
-chmod +x /usr/local/bin/bazel
-
-useradd -m -s /bin/bash appuser
-su - appuser
-cd /app
-```

--- a/sortcpp/pymodule/BUILD.bazel
+++ b/sortcpp/pymodule/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 py_library(
     name = "pymodule",
     srcs = ["__init__.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@poetry_lock_file//deps:numpy",
@@ -14,7 +13,6 @@ py_library(
 py_test(
     name = "pymodule_test",
     srcs = ["__test__.py"],
-    imports = ["../.."],
     main = "__test__.py",
     deps = [
         "@poetry_lock_file//deps:numpy",


### PR DESCRIPTION
Update bazel dependencies and readme

- Upgrade rules_python to 1.6.3
- Actualize Readme
- Organize MODULE.bazel
- Mention remote build and execution
- Update build inside docker container